### PR TITLE
Fix build error with std::div(uint32_t, uint32_t)

### DIFF
--- a/src/dsd_decimator.cpp
+++ b/src/dsd_decimator.cpp
@@ -270,7 +270,7 @@ template<> void dsdDecimator::getSamples(double *buffer, dsf2flac_uint32 bufferL
 template <typename sampleType> void dsdDecimator::getSamplesInternal(sampleType *buffer, dsf2flac_uint32 bufferLen, dsf2flac_float64 scale, dsf2flac_float64 tpdfDitherPeakAmplitude, bool roundToInt)
 {
 	// check the buffer seems sensible
-	div_t d = div(bufferLen,getNumChannels());
+	div_t d = div((dsf2flac_int32)bufferLen,(dsf2flac_int32)getNumChannels());
 	if (d.rem) {
 		fputs("Buffer length is not a multiple of getNumChannels()",stderr);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
There's no such overload, leading to build failure on some systems:

```
dsd_decimator.cpp:182:42: error: call of overloaded ‘div(dsf2flac_uint32&, dsf2flac_uint32)’ is ambiguous
  div_t d = div(bufferLen,getNumChannels());
                                          ^
In file included from /usr/include/c++/6.1.1/cstdlib:75:0,
                 from /usr/include/boost/config/platform/linux.hpp:15,
                 from /usr/include/boost/config.hpp:57,
                 from /usr/include/boost/circular_buffer_fwd.hpp:18,
                 from /usr/include/boost/circular_buffer.hpp:18,
                 from /home/grayshade/.cache/pacaur/dsf2flac-svn/src/dsf2flac/src/dsd_sample_reader.h:43,
                 from /home/grayshade/.cache/pacaur/dsf2flac-svn/src/dsf2flac/src/dsd_decimator.h:54,
                 from /home/grayshade/.cache/pacaur/dsf2flac-svn/src/dsf2flac/src/dsd_decimator.cpp:38:
/usr/include/stdlib.h:788:14: note: candidate: div_t div(int, int)
 extern div_t div (int __numer, int __denom)
              ^~~
In file included from /usr/include/boost/config/platform/linux.hpp:15:0,
                 from /usr/include/boost/config.hpp:57,
                 from /usr/include/boost/circular_buffer_fwd.hpp:18,
                 from /usr/include/boost/circular_buffer.hpp:18,
                 from /home/grayshade/.cache/pacaur/dsf2flac-svn/src/dsf2flac/src/dsd_sample_reader.h:43,
                 from /home/grayshade/.cache/pacaur/dsf2flac-svn/src/dsf2flac/src/dsd_decimator.h:54,
                 from /home/grayshade/.cache/pacaur/dsf2flac-svn/src/dsf2flac/src/dsd_decimator.cpp:38:
/usr/include/c++/6.1.1/cstdlib:233:3: note: candidate: lldiv_t __gnu_cxx::div(long long int, long long int)
   div(long long __n, long long __d)
   ^~~
/usr/include/c++/6.1.1/cstdlib:175:3: note: candidate: ldiv_t std::div(long int, long int)
   div(long __i, long __j) { return ldiv(__i, __j); }
   ^~~
```
