### PR TITLE
Fix build with boost 1.76

### DIFF
--- a/src/fstream_plus.cpp
+++ b/src/fstream_plus.cpp
@@ -56,12 +56,12 @@ fstreamPlus::~fstreamPlus()
 }
 
 /** Overload seekg methods to return true on fail **/
-bool fstreamPlus::seekg(streampos pos)
+bool fstreamPlus::seekg(std::streampos pos)
 {
 	std::fstream::seekg(pos);
 	return !good();
 }
-bool fstreamPlus::seekg(streamoff pos, ios_base::seekdir way)
+bool fstreamPlus::seekg(std::streamoff pos, ios_base::seekdir way)
 {
 	std::fstream::seekg(pos,way);
 	return !good();

--- a/src/fstream_plus.h
+++ b/src/fstream_plus.h
@@ -60,8 +60,8 @@ public:
 	virtual ~fstreamPlus();
 	
 	/** Overload seekg methods to return true on fail **/
-	bool seekg(streampos pos);
-	bool seekg(streamoff pos, ios_base::seekdir way);
+	bool seekg(std::streampos pos);
+	bool seekg(std::streamoff pos, ios_base::seekdir way);
 	
 	/** Additional read methods - native bit order **/
 	// All return true on error. All read "n" numbers (not n chars/bytes!)


### PR DESCRIPTION
Hello, I'm the maintainer of the AUR pkgbuild for this program, it has been reported that the program failed to compile with boost 1.76, luckily has been reported a fix too https://aur.archlinux.org/packages/dsf2flac-git/#comment-812801