### PR TITLE
Fix issues with type width for 32-bit machines

### DIFF
--- a/src/dsdiff_file_reader.cpp
+++ b/src/dsdiff_file_reader.cpp
@@ -37,13 +37,16 @@
 
 
 #include "dsdiff_file_reader.h"
-#include "iostream"
 #include "libdstdec/dst_init.h"
 #include "libdstdec/dst_fram.h"
+#include <iostream>
+#include <cinttypes>
+
 static bool chanIdentsAllocated = false;
 static bool sampleBufferAllocated = false;
 static ebunch dstEbunch;
 static bool dstEbunchAllocated = false;
+
 DsdiffFileReader::DsdiffFileReader(char* filePath) : DsdSampleReader()
 {
 	// set some defaults
@@ -810,10 +813,10 @@ void DsdiffFileReader::processTracks() {
 
 void DsdiffFileReader::dispMarker(DsdiffMarker m)
 {
-	printf("\nmarkType:\t%u\n",m.markType);
-	printf("time:\t%u:%u:%u::%u + %u\n",m.hours,m.minutes,m.seconds,m.samples,m.offset);
-	printf("markChannel:\t\t%u\n",m.markChannel);
-	printf("trackFlags:\t\t%u\n",m.trackFlags);
+	printf("\nmarkType:\t%" PRIu16 "\n",m.markType);
+	printf("time:\t%" PRIu16 ":%" PRIu8 ":%" PRIu8 "::%" PRIu32 " + %" PRIi32 "\n",m.hours,m.minutes,m.seconds,m.samples,m.offset);
+	printf("markChannel:\t\t%" PRIu16 "\n",m.markChannel);
+	printf("trackFlags:\t\t%" PRIu16 "\n",m.trackFlags);
 	printf("markerText:\t%s\n",m.markerText);
 	//printf("count:\t\t%u\n",m.count);
 }
@@ -884,14 +887,14 @@ bool DsdiffFileReader::readChunk_COMT(dsf2flac_uint64 chunkStart)
 
 void DsdiffFileReader::dispComment(DsdiffComment c)
 {
-	printf("timeStampYear:\t%u\n",c.timeStampYear);
-	printf("timeStampMonth:\t%u\n",c.timeStampMonth);
-	printf("timeStampDay:\t%u\n",c.timeStampDay);
-	printf("timeStampHour:\t%u\n",c.timeStampHour);
-	printf("timeStampMinutes:\t%u\n",c.timeStampMinutes);
-	printf("cmtType:\t%u\n",c.cmtType);
-	printf("cmtRef:\t\t%u\n",c.cmtRef);
-	printf("count:\t\t%u\n",c.count);
+	printf("timeStampYear:\t%" PRIu16 "\n",c.timeStampYear);
+	printf("timeStampMonth:\t%" PRIu8 "\n",c.timeStampMonth);
+	printf("timeStampDay:\t%" PRIu8 "\n",c.timeStampDay);
+	printf("timeStampHour:\t%" PRIu8 "\n",c.timeStampHour);
+	printf("timeStampMinutes:\t%" PRIu8 "\n",c.timeStampMinutes);
+	printf("cmtType:\t%" PRIu16 "\n",c.cmtType);
+	printf("cmtRef:\t\t%" PRIu16 "\n",c.cmtRef);
+	printf("count:\t\t%" PRIu32 "\n",c.count);
 	printf("commentText:\t%s\n",c.commentText);
 }
 
@@ -1051,16 +1054,16 @@ bool DsdiffFileReader::checkIdent(dsf2flac_int8* a, dsf2flac_int8* b)
 void DsdiffFileReader::dispFileInfo()
 {
 	printf("dsdiffVersion: %08x\n",dsdiffVersion);
-	printf("samplingRate: %u\n",samplingFreq);
-	printf("chanNum: %u\n",chanNum);
+	printf("samplingRate: %" PRIu32 "\n",samplingFreq);
+	printf("chanNum: %" PRIu16 "\n",chanNum);
 	for (int i=0; i<chanNum; i++)
-		printf("chanIdent%u: %s\n",i,chanIdents[i]);
+		printf("chanIdent%d: %s\n",i,chanIdents[i]);
 	printf("compressionType: %s\n",compressionType);
 	printf("compressionName: %s\n",compressionName);
-	printf("ast_hours: %u\n",ast.hours);
-	printf("ast_mins: %d\n",ast.minutes);
-	printf("ast_secs: %d\n",ast.seconds);
-	printf("ast_samples: %u\n",ast.samples);
-	printf("sampleDataPointer: %lu\n",sampleDataPointer);
-	printf("sampleCount: %lu\n",sampleCountPerChan);
+	printf("ast_hours: %" PRIu16 "\n",ast.hours);
+	printf("ast_mins: %" PRIu8 "\n",ast.minutes);
+	printf("ast_secs: %" PRIu8 "\n",ast.seconds);
+	printf("ast_samples: %" PRIu32 "\n",ast.samples);
+	printf("sampleDataPointer: %" PRIu64 "\n",sampleDataPointer);
+	printf("sampleCount: %" PRIu64 "\n",sampleCountPerChan);
 }

--- a/src/dsf2flac_types.h
+++ b/src/dsf2flac_types.h
@@ -35,16 +35,17 @@
  *
  */
 
-// correct for linux AMD64, other platforms must be added!
-typedef char 				dsf2flac_int8;
-typedef short int			dsf2flac_int16;
-typedef int					dsf2flac_int32;
-typedef long int			dsf2flac_int64;
+#include <cinttypes>
 
-typedef unsigned char 		dsf2flac_uint8;
-typedef unsigned short int	dsf2flac_uint16;
-typedef unsigned int		dsf2flac_uint32;
-typedef unsigned long int	dsf2flac_uint64;
+typedef char 			dsf2flac_int8;
+typedef int16_t			dsf2flac_int16;
+typedef int32_t			dsf2flac_int32;
+typedef int64_t			dsf2flac_int64;
 
-typedef	float				dsf2flac_float32;
-typedef double				dsf2flac_float64;
+typedef uint8_t         dsf2flac_uint8;
+typedef uint16_t        dsf2flac_uint16;
+typedef uint32_t        dsf2flac_uint32;
+typedef uint64_t        dsf2flac_uint64;
+
+typedef	float			dsf2flac_float32;
+typedef double			dsf2flac_float64;

--- a/src/dsf_file_reader.cpp
+++ b/src/dsf_file_reader.cpp
@@ -350,18 +350,16 @@ bool DsfFileReader::checkIdent(dsf2flac_int8* a, dsf2flac_int8* b)
 
 void DsfFileReader::dispFileInfo()
 {
-	printf("filesize: %lu\n",fileSz);
-	printf("metaChunkPointer: %lu\n",metaChunkPointer);
-	printf("sampleDataPointer: %lu\n",sampleDataPointer);
-	printf("dataChunkSz: %lu\n",dataChunkSz);
-	printf("formatVer: %u\n",formatVer);
-	printf("formatID: %u\n",formatID);
-	printf("chanType: %u\n",chanType);
-	printf("chanNum: %u\n",chanNum);
-	printf("samplingFreq: %u\n",samplingFreq);
-	printf("samplesPerChar: %u\n",samplesPerChar);
-	printf("sampleCount: %lu\n",sampleCount);
-	printf("blockSzPerChan: %u\n",blockSzPerChan);
-
-	return;
+	printf("filesize: %" PRIu64 "\n",fileSz);
+	printf("metaChunkPointer: %" PRIu64 "\n",metaChunkPointer);
+	printf("sampleDataPointer: %" PRIu64 "\n",sampleDataPointer);
+	printf("dataChunkSz: %" PRIu64 "\n",dataChunkSz);
+	printf("formatVer: %" PRIu32 "\n",formatVer);
+	printf("formatID: %" PRIu32 "\n",formatID);
+	printf("chanType: %" PRIu32 "\n",chanType);
+	printf("chanNum: %" PRIu32 "\n",chanNum);
+	printf("samplingFreq: %" PRIu32 "\n",samplingFreq);
+	printf("samplesPerChar: %" PRIu32 "\n",samplesPerChar);
+	printf("sampleCount: %" PRIu64 "\n",sampleCount);
+	printf("blockSzPerChan: %" PRIu32 "\n",blockSzPerChan);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@
 #include <FLAC++/metadata.h>
 #include <FLAC++/encoder.h>
 #include <sstream>
-#include <math.h>
+#include <cmath>
 #include "cmdline.h"
 #include "dsd_decimator.h"
 #include "dsf_file_reader.h"


### PR DESCRIPTION
This PR fixes the issues with type width for builds on 32-bit machines, resulting in "Sorry, only one bit data is supported" message.

The issue was caused by usage of long type as 64-bit size type, which is in general case not true (the standard only guarantees that sizeof(int) <= sizeof(long)). This resulted in fstreamPlus::read_uint64 method reading only 32 bits and incorrectly parsing the DSD header on machines where sizeof(unsigned long) != 8.

Fixes #20.