### PR TITLE
Handle DIAR and DITI DSDIFF metadata chunks

### DIFF
--- a/src/dsdiff_file_reader.cpp
+++ b/src/dsdiff_file_reader.cpp
@@ -631,17 +631,55 @@ bool DsdiffFileReader::readChunk_DIIN(dsf2flac_uint64 chunkStart)
 		// read the header
 		if (!readChunkHeader(ident,subChunkStart,&subChunkSz))
 			return false;
-		// see if we know how to read this chunk
 		if ( !emidRead && checkIdent(ident,const_cast<dsf2flac_int8*>("EMID")) ) {
 			emidRead = readChunk_EMID(subChunkStart);
+		} else if ( checkIdent(ident,const_cast<dsf2flac_int8*>("DIAR")) ) {
+			readChunk_DIAR(subChunkStart);
+		} else if ( checkIdent(ident,const_cast<dsf2flac_int8*>("DITI")) ) {
+			readChunk_DITI(subChunkStart);
 		} else if ( checkIdent(ident,const_cast<dsf2flac_int8*>("MARK")) ) {
 			readChunk_MARK(subChunkStart);
-		} else
-			fprintf(stderr,"WARNING: unknown chunk type: %s\n",ident);
+		} else fprintf(stderr,"WARNING: unknown chunk type: %s\n",ident);
 		// move to the next chunk
 		subChunkStart = subChunkStart + subChunkSz;
 	}
 	return true;
+}
+
+bool DsdiffFileReader::readChunk_DIAR(dsf2flac_uint64 chunkStart)
+{
+    dsf2flac_int8 ident[5];
+    ident[4] = '\0';
+
+    dsf2flac_uint64 chunkSz;
+
+    if (!readChunkHeader(ident, chunkStart, &chunkSz)) return false;
+
+    if ( !checkIdent(ident, const_cast<dsf2flac_int8*>("DIAR")) ) {
+        errorMsg = "dsdiffFileReader::readChunk_DIAR:chunk ident error";
+        return false;
+    }
+
+    // DIAR is optional edited-master metadata. Ignore its contents.
+    return true;
+}
+
+bool DsdiffFileReader::readChunk_DITI(dsf2flac_uint64 chunkStart)
+{
+    dsf2flac_int8 ident[5];
+    ident[4] = '\0';
+
+    dsf2flac_uint64 chunkSz;
+
+    if (!readChunkHeader(ident, chunkStart, &chunkSz)) return false;
+
+    if ( !checkIdent(ident, const_cast<dsf2flac_int8*>("DITI")) ) {
+        errorMsg = "dsdiffFileReader::readChunk_DITI:chunk ident error";
+        return false;
+    }
+
+    // DITI is optional edited-master metadata. Ignore its contents.
+    return true;
 }
 
 bool DsdiffFileReader::readChunk_EMID(dsf2flac_uint64 chunkStart)

--- a/src/dsdiff_file_reader.cpp
+++ b/src/dsdiff_file_reader.cpp
@@ -41,6 +41,7 @@
 #include "libdstdec/dst_fram.h"
 #include <iostream>
 #include <cinttypes>
+#include <cstring>
 
 static bool chanIdentsAllocated = false;
 static bool sampleBufferAllocated = false;
@@ -59,7 +60,9 @@ DsdiffFileReader::DsdiffFileReader(char* filePath) : DsdSampleReader()
 	bufferMarker = 0;
 	errorMsg = "";
 	lsConfig=65535;
-	isEm=false;
+	emid=NULL;
+	diar=NULL;
+	diti=NULL;
 	// first let's open the file
 	file.open(filePath, fstreamPlus::in | fstreamPlus::binary);
 	// throw exception if that did not work.
@@ -114,8 +117,14 @@ DsdiffFileReader::~DsdiffFileReader()
 	}
 	markers.clear();
 	// free emid
-	if (isEm)
+	if (emid)
 		delete[] emid;
+	// free diar
+	if (diar)
+		delete[] diar;
+	// free diti
+	if (diti)
+		delete[] diti;
 	
 	// free the DST decoder (assuming one was used)
 	if (dstEbunchAllocated) {
@@ -246,10 +255,34 @@ dsf2flac_uint64 DsdiffFileReader::getTrackEnd(dsf2flac_uint32 trackNum) {
 		
 }
 
- ID3_Tag DsdiffFileReader::getID3Tag(dsf2flac_uint32 trackNum) {
-	if (trackNum >= tags.size())
-		return NULL;
-	return tags[trackNum];
+ID3_Tag DsdiffFileReader::makeDIINID3Tag()
+{
+    ID3_Tag tag;
+
+    if (diar && strlen(diar) > 0) {
+        ID3_Frame* frame = new ID3_Frame(ID3FID_LEADARTIST);
+        frame->Field(ID3FN_TEXT).Set(diar);
+        tag.AddFrame(frame);
+    }
+
+    if (diti && strlen(diti) > 0) {
+        ID3_Frame* frame = new ID3_Frame(ID3FID_ALBUM);
+        frame->Field(ID3FN_TEXT).Set(diti);
+        tag.AddFrame(frame);
+    }
+
+    return tag;
+}
+
+ID3_Tag DsdiffFileReader::getID3Tag(dsf2flac_uint32 trackNum)
+{
+    if (trackNum < tags.size()) return tags[trackNum];
+
+    if ((diar && strlen(diar) > 0) || (diti && strlen(diti) > 0)) {
+        return makeDIINID3Tag();
+    }
+
+    return NULL;
 }
 
 bool DsdiffFileReader::readHeaders()
@@ -661,8 +694,14 @@ bool DsdiffFileReader::readChunk_DIAR(dsf2flac_uint64 chunkStart)
         return false;
     }
 
-    // DIAR is optional edited-master metadata. Ignore its contents.
-    return true;
+    if (diar) {
+        delete[] diar;
+        diar = NULL;
+    }
+
+    diar = readDIINText(chunkSz);
+
+    return diar != NULL;
 }
 
 bool DsdiffFileReader::readChunk_DITI(dsf2flac_uint64 chunkStart)
@@ -679,8 +718,51 @@ bool DsdiffFileReader::readChunk_DITI(dsf2flac_uint64 chunkStart)
         return false;
     }
 
-    // DITI is optional edited-master metadata. Ignore its contents.
-    return true;
+    if (diti) {
+        delete[] diti;
+        diti = NULL;
+    }
+
+    diti = readDIINText(chunkSz);
+
+    return diti != NULL;
+}
+
+char* DsdiffFileReader::readDIINText(dsf2flac_uint64 chunkSz)
+{
+    dsf2flac_uint32 count;
+
+    if (file.read_uint32_rev(&count,1)) {
+        errorMsg = "dsdiffFileReader::readDIINText:file read error";
+        return NULL;
+    }
+
+    // chunkSz includes the 12-byte DSDIFF chunk header.
+    // DIAR/DITI payload is:
+    //   uint32 count
+    //   char text[count]
+    if (chunkSz < 16) {
+        errorMsg = "dsdiffFileReader::readDIINText:invalid chunk size";
+        return NULL;
+    }
+
+    dsf2flac_uint64 maxCount = chunkSz - 12 - 4;
+
+    if (count > maxCount) {
+        errorMsg = "dsdiffFileReader::readDIINText:invalid text length";
+        return NULL;
+    }
+
+    char* text = new char[count + 1];
+    text[count] = '\0';
+
+    if (count > 0 && file.read_int8(text,count)) {
+        delete[] text;
+        errorMsg = "dsdiffFileReader::readDIINText:file read error";
+        return NULL;
+    }
+
+    return text;
 }
 
 bool DsdiffFileReader::readChunk_EMID(dsf2flac_uint64 chunkStart)
@@ -696,7 +778,6 @@ bool DsdiffFileReader::readChunk_EMID(dsf2flac_uint64 chunkStart)
 		errorMsg = "dsdiffFileReader::readChunk_EMID:chunk ident error";
 		return false;
 	}
-	isEm = true;
 	dsf2flac_uint64 n = chunkSz - 12;
 	emid = new char[n + 1];
 	emid[n] = '\0';

--- a/src/dsdiff_file_reader.cpp
+++ b/src/dsdiff_file_reader.cpp
@@ -631,6 +631,7 @@ bool DsdiffFileReader::readChunk_DIIN(dsf2flac_uint64 chunkStart)
 		// read the header
 		if (!readChunkHeader(ident,subChunkStart,&subChunkSz))
 			return false;
+		// see if we know how to read this chunk
 		if ( !emidRead && checkIdent(ident,const_cast<dsf2flac_int8*>("EMID")) ) {
 			emidRead = readChunk_EMID(subChunkStart);
 		} else if ( checkIdent(ident,const_cast<dsf2flac_int8*>("DIAR")) ) {

--- a/src/dsdiff_file_reader.h
+++ b/src/dsdiff_file_reader.h
@@ -176,6 +176,10 @@ private: // private methods
 	bool readChunk_DIAR(dsf2flac_uint64 chunkStart);
 	/// read data from a DITI chunk
 	bool readChunk_DITI(dsf2flac_uint64 chunkStart);
+	/// read a DIIN text chunk payload
+	char* readDIINText(dsf2flac_uint64 chunkSz);
+	/// create a synthetic ID3 tag from DIIN metadata
+	ID3_Tag makeDIINID3Tag();
 	/// read data from a MARK chunk
 	bool readChunk_MARK(dsf2flac_uint64 chunkStart);
 	/// read data from a DSTI chunk
@@ -206,8 +210,9 @@ private:
 	std::vector<DsdiffComment> comments;
 	std::vector<ID3_Tag> tags;
 	std::vector<DsdiffMarker> markers;
-	bool isEm;
 	char* emid;
+	char* diar;
+	char* diti;
 	std::vector<DSTFrameIndex> dstFrameIndices;
 	DSTFrameInformation dstInfo;
 	// track info

--- a/src/dsdiff_file_reader.h
+++ b/src/dsdiff_file_reader.h
@@ -172,6 +172,10 @@ private: // private methods
 	bool readChunk_DIIN(dsf2flac_uint64 chunkStart);
 	/// read data from a EMID chunk
 	bool readChunk_EMID(dsf2flac_uint64 chunkStart);
+	/// read data from a DIAR chunk
+	bool readChunk_DIAR(dsf2flac_uint64 chunkStart);
+	/// read data from a DITI chunk
+	bool readChunk_DITI(dsf2flac_uint64 chunkStart);
 	/// read data from a MARK chunk
 	bool readChunk_MARK(dsf2flac_uint64 chunkStart);
 	/// read data from a DSTI chunk


### PR DESCRIPTION
This PR adds explicit handling for the optional DSDIFF Edited Master metadata chunks:

- `DIAR` — Artist Chunk
- `DITI` — Title Chunk

These chunks are valid optional subchunks of the `DIIN` Edited Master Information chunk in DSDIFF 1.5. Previously they fell through to the unknown-chunk warning path during DoP conversion, producing warnings such as:

```text
WARNING: unknown chunk type: DIAR
WARNING: unknown chunk type: DITI